### PR TITLE
Added NoToggle param to Mute cmdlet

### DIFF
--- a/AudioDeviceCmdlets/DefaultAudioCmdlets.cs
+++ b/AudioDeviceCmdlets/DefaultAudioCmdlets.cs
@@ -172,13 +172,21 @@ namespace AudioDeviceCmdlets
     [Cmdlet(VerbsCommon.Set, "DefaultAudioDeviceMute")]
     public class SetDefaultAudioDeviceMute : Cmdlet
     {
+        [Parameter]
+        public SwitchParameter NoToggle
+        {
+            get { return noToggle; }
+            set { noToggle = value; }
+        }
+        private bool noToggle;
+
         protected override void ProcessRecord()
         {
             MMDeviceEnumerator DevEnum = new MMDeviceEnumerator();
             MMDeviceCollection devices = DevEnum.EnumerateAudioEndPoints(EDataFlow.eRender, EDeviceState.DEVICE_STATE_ACTIVE);
             MMDevice defaultDevice = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eMultimedia);
 
-            defaultDevice.AudioEndpointVolume.Mute = !defaultDevice.AudioEndpointVolume.Mute;
+            defaultDevice.AudioEndpointVolume.Mute = NoToggle || !defaultDevice.AudioEndpointVolume.Mute;
         }
     }
 


### PR DESCRIPTION
Hi there - please forgive the intrusion, I've never contributed a pull request to any project before so I'm not sure if I'm out of order by sending this unsolicited. However I wanted to offer my thanks for this project which I've found extremely useful. There's one use case where I wanted the `Set-DefaultAudioDeviceMute` command to _always_ mute the sound, not toggle it on and off, so I've added this `-NoToggle` switch parameter which does the trick for me. This is in the attached pull request: if you're happy to accept it I don't mind also contributing a change to the help document. Cheers! Daniel
