### PR TITLE
Made install script hands-off, more dynamic to handle later releases.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Set volume and mute state of default audio device (playback/recording)
 
 
 ## Import Cmdlet to PowerShell
-You can choose to manually download <a href="https://github.com/frgnca/AudioDeviceCmdlets/releases/download/v3.0/AudioDeviceCmdlets.dll">AudioDeviceCmdlets.dll</a>
+Run the script below for a hands-free installation. This will get the latest dll asset, create the module directory and install the module.
 ```powershell
 # Setup
 # Checks if the module is installed, if not, will download from v3.0 release and install the module.
@@ -40,7 +40,6 @@ if (!(get-module -name AudioDeviceCmdlets)) {
     Copy-Item  $dllDownloadPath $dllDestinationPath
     Set-Location $modulePath
     Get-ChildItem | Unblock-File
-    start-sleep -s 3
     Import-Module AudioDeviceCmdlets -force
 }
 ```

--- a/README.md
+++ b/README.md
@@ -11,13 +11,27 @@ Set volume and mute state of default audio device (playback/recording)
 
 
 ## Import Cmdlet to PowerShell
-Download <a href="https://github.com/frgnca/AudioDeviceCmdlets/releases/download/v3.0/AudioDeviceCmdlets.dll">AudioDeviceCmdlets.dll</a>
+You can choose to manually download <a href="https://github.com/frgnca/AudioDeviceCmdlets/releases/download/v3.0/AudioDeviceCmdlets.dll">AudioDeviceCmdlets.dll</a>
 ```powershell
-New-Item "$($profile | split-path)\Modules\AudioDeviceCmdlets" -Type directory -Force
-Copy-Item "C:\Path\to\AudioDeviceCmdlets.dll" "$($profile | split-path)\Modules\AudioDeviceCmdlets\AudioDeviceCmdlets.dll"
-Set-Location "$($profile | Split-Path)\Modules\AudioDeviceCmdlets"
-Get-ChildItem | Unblock-File
-Import-Module AudioDeviceCmdlets
+# Setup
+# Checks if the module is installed, if not, will download from v3.0 release and install the module.
+if (!(get-module -name AudioDeviceCmdlets)) {
+    $modulePath = "$($profile | split-path)\Modules\AudioDeviceCmdlets"
+    $fileName = "AudioDeviceCmdlets.dll"
+    $dllURL = "https://github.com/frgnca/AudioDeviceCmdlets/releases/download/v3.0/$fileName"
+    $dllDownloadPath = "$env:USERPROFILE\Downloads\$fileName"
+    $dllDestinationPath = "$modulePath\$fileName"
+    if (!(test-path $dllDownloadPath)) {
+        Invoke-WebRequest -Uri $dllURL -OutFile $dllDownloadPath
+    }
+    if (!(Test-Path $modulePath)) {
+        New-Item $modulePath -Type directory -Force
+    }
+    Copy-Item  $dllDownloadPath $dllFilePath
+    Set-Location $modulePath
+    Get-ChildItem | Unblock-File
+    Import-Module AudioDeviceCmdlets -Force
+}
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -15,10 +15,20 @@ You can choose to manually download <a href="https://github.com/frgnca/AudioDevi
 ```powershell
 # Setup
 # Checks if the module is installed, if not, will download from v3.0 release and install the module.
+function Get-LatestGitHubVersion {
+    $repo = "frgnca/AudioDeviceCmdlets"
+
+    $releases = "https://api.github.com/repos/$repo/releases"
+    $releases
+    $downloadURL = (Invoke-WebRequest $releases | ConvertFrom-Json)[0].assets[0].browser_download_url
+
+    return $downloadURL
+}
 if (!(get-module -name AudioDeviceCmdlets)) {
     $modulePath = "$($profile | split-path)\Modules\AudioDeviceCmdlets"
     $fileName = "AudioDeviceCmdlets.dll"
-    $dllURL = "https://github.com/frgnca/AudioDeviceCmdlets/releases/download/v3.0/$fileName"
+    #dllURL = "https://github.com/frgnca/AudioDeviceCmdlets/releases/download/v3.0/AudioDeviceCmdlets.dll"
+    $dllURL = Get-LatestGitHubVersion
     $dllDownloadPath = "$env:USERPROFILE\Downloads\$fileName"
     $dllDestinationPath = "$modulePath\$fileName"
     if (!(test-path $dllDownloadPath)) {
@@ -27,10 +37,11 @@ if (!(get-module -name AudioDeviceCmdlets)) {
     if (!(Test-Path $modulePath)) {
         New-Item $modulePath -Type directory -Force
     }
-    Copy-Item  $dllDownloadPath $dllFilePath
+    Copy-Item  $dllDownloadPath $dllDestinationPath
     Set-Location $modulePath
     Get-ChildItem | Unblock-File
-    Import-Module AudioDeviceCmdlets -Force
+    start-sleep -s 3
+    Import-Module AudioDeviceCmdlets -force
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ function Get-LatestGitHubVersion {
 
     $releases = "https://api.github.com/repos/$repo/releases"
     $releases
-    $downloadURL = (Invoke-WebRequest $releases | ConvertFrom-Json)[0].assets[0].browser_download_url
+    [uri]$downloadURL = (Invoke-WebRequest $releases | ConvertFrom-Json)[0].assets[0].browser_download_url
 
     return $downloadURL
 }
@@ -31,9 +31,7 @@ if (!(get-module -name AudioDeviceCmdlets)) {
     $dllURL = Get-LatestGitHubVersion
     $dllDownloadPath = "$env:USERPROFILE\Downloads\$fileName"
     $dllDestinationPath = "$modulePath\$fileName"
-    if (!(test-path $dllDownloadPath)) {
-        Invoke-WebRequest -Uri $dllURL -OutFile $dllDownloadPath
-    }
+    Invoke-WebRequest -Uri $dllURL -OutFile $dllDownloadPath
     if (!(Test-Path $modulePath)) {
         New-Item $modulePath -Type directory -Force
     }


### PR DESCRIPTION
The current install script requires the user to download the DLL manually.

This update will check if the module is installed. If it's not, it will go through the install process and also checks for if the DLL is already downloaded.