### PR TITLE
Add -DefaultOnly and -CommunicationOnly parameter to Set-AudioDevice

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ Write-AudioDevice -PlaybackMeter  # Writes the default playback device's power o
 		Name: AudioDeviceCmdlets
 		Output type: Class Library
 
-2. Install System.Management.Automation NuGet package  
+2. Install System.Management.Automation NuGet legacy package, which is packaged as part of Microsoft.PowerShell.5.1.ReferenceAssemblies
     Project -> Manage NuGet Packages...
 
-		Browse: System.Management.Automation
-		Install: v6.3+
+		Browse: Microsoft.PowerShell.5.1.ReferenceAssemblies
+		Install: v1.0.0+
 
 3. Set project properties  
 	Project -> AudioDeviceCmdlets Properties...

--- a/README.md
+++ b/README.md
@@ -30,15 +30,15 @@ Get-AudioDevice -List             # Outputs a list of all devices as <AudioDevic
                 -RecordingVolume  # Outputs the default recording device's volume level on 100 as <float>
 ```
 ```PowerShell
-Set-AudioDevice <AudioDevice>             # Sets the default playback/recording device to the given <AudioDevice>, can be piped
-                    -PlaybackOnly         # Only set default playback device, not communication device
-                    -CommunicationOnly    # Only set default communication device, not playback device
-                -ID <string>              # Sets the default playback/recording device to the device with the ID corresponding to the given <string>
-                    -PlaybackOnly         # Only set default playback device, not communication device
-                    -CommunicationOnly    # Only set default communication device, not playback device
-                -Index <int>              # Sets the default playback/recording device to the device with the Index corresponding to the given <int>
-                    -PlaybackOnly         # Only set default playback device, not communication device
-                    -CommunicationOnly    # Only set default communication device, not playback device
+Set-AudioDevice <AudioDevice>             # Set the given playback/recording device as both the default device and the default communication device, for its type. Can be piped.
+                    -DefaultOnly          # Only set default device, not communication device
+                    -CommunicationOnly    # Only set default communication device, not default device
+                -ID <string>              # Set the device with the ID corresponding to the given <string> as both the default device and the default communication device, for its type
+                    -DefaultOnly          # Only set default device, not communication device
+                    -CommunicationOnly    # Only set default communication device, not default device
+                -Index <int>              # Set the device with the Index corresponding to the given <int> as both the default device and the default communication device, for its type
+                    -DefaultOnly          # Only set default device, not communication device
+                    -CommunicationOnly    # Only set default communication device, not default device
                 -PlaybackMute <bool>      # Sets the default playback device's mute state to the given <bool>
                 -PlaybackMuteToggle       # Toggles the default playback device's mute state
                 -PlaybackVolume <float>   # Sets the default playback device's volume level on 100 to the given <float>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Install-Module -Name AudioDeviceCmdlets
 Get-AudioDevice -List             # Outputs a list of all devices as <AudioDevice>
                 -ID <string>      # Outputs the device with the ID corresponding to the given <string>
                 -Index <int>      # Outputs the device with the Index corresponding to the given <int>
-		-Playback         # Outputs the default playback device as <AudioDevice>
+                -Playback         # Outputs the default playback device as <AudioDevice>
                 -PlaybackMute     # Outputs the default playback device's mute state as <bool>
                 -PlaybackVolume   # Outputs the default playback device's volume level on 100 as <float>
                 -Recording        # Outputs the default recording device as <AudioDevice>
@@ -31,8 +31,11 @@ Get-AudioDevice -List             # Outputs a list of all devices as <AudioDevic
 ```
 ```PowerShell
 Set-AudioDevice <AudioDevice>             # Sets the default playback/recording device to the given <AudioDevice>, can be piped
+                    -PlaybackOnly         # Only set default playback device, not communication device
                 -ID <string>              # Sets the default playback/recording device to the device with the ID corresponding to the given <string>
+                    -PlaybackOnly         # Only set default playback device, not communication device
                 -Index <int>              # Sets the default playback/recording device to the device with the Index corresponding to the given <int>
+                    -PlaybackOnly         # Only set default playback device, not communication device
                 -PlaybackMute <bool>      # Sets the default playback device's mute state to the given <bool>
                 -PlaybackMuteToggle       # Toggles the default playback device's mute state
                 -PlaybackVolume <float>   # Sets the default playback device's volume level on 100 to the given <float>
@@ -58,7 +61,7 @@ Write-AudioDevice -PlaybackMeter  # Writes the default playback device's power o
 		Name: AudioDeviceCmdlets
 		Output type: Class Library
 
-2. Install System.Management.Automation NuGet legacy package, which is packaged as part of Microsoft.PowerShell.5.1.ReferenceAssemblies
+2. Install System.Management.Automation NuGet legacy package, which is packaged as part of Microsoft.PowerShell.5.1.ReferenceAssemblies  
     Project -> Manage NuGet Packages...
 
 		Browse: Microsoft.PowerShell.5.1.ReferenceAssemblies

--- a/README.md
+++ b/README.md
@@ -32,10 +32,13 @@ Get-AudioDevice -List             # Outputs a list of all devices as <AudioDevic
 ```PowerShell
 Set-AudioDevice <AudioDevice>             # Sets the default playback/recording device to the given <AudioDevice>, can be piped
                     -PlaybackOnly         # Only set default playback device, not communication device
+                    -CommunicationOnly    # Only set default communication device, not playback device
                 -ID <string>              # Sets the default playback/recording device to the device with the ID corresponding to the given <string>
                     -PlaybackOnly         # Only set default playback device, not communication device
+                    -CommunicationOnly    # Only set default communication device, not playback device
                 -Index <int>              # Sets the default playback/recording device to the device with the Index corresponding to the given <int>
                     -PlaybackOnly         # Only set default playback device, not communication device
+                    -CommunicationOnly    # Only set default communication device, not playback device
                 -PlaybackMute <bool>      # Sets the default playback device's mute state to the given <bool>
                 -PlaybackMuteToggle       # Toggles the default playback device's mute state
                 -PlaybackVolume <float>   # Sets the default playback device's volume level on 100 to the given <float>

--- a/SOURCE/AudioDeviceCmdlets.cs
+++ b/SOURCE/AudioDeviceCmdlets.cs
@@ -408,6 +408,17 @@ namespace AudioDeviceCmdlets
         }
         private float? recordingvolume;
 
+        // Parameter called to only set device as default playback and not default communication
+        [Parameter(Mandatory = false, ParameterSetName = "InputObject")]
+        [Parameter(Mandatory = false, ParameterSetName = "ID")]
+        [Parameter(Mandatory = false, ParameterSetName = "Index")]
+        public SwitchParameter PlaybackOnly
+        {
+            get { return playbackOnly; }
+            set { playbackOnly = value; }
+        }
+        private SwitchParameter playbackOnly;
+
         // Cmdlet execution
         protected override void ProcessRecord()
         {
@@ -428,7 +439,8 @@ namespace AudioDeviceCmdlets
                         // Create a new audio PolicyConfigClient
                         PolicyConfigClient client = new PolicyConfigClient();
                         // Using PolicyConfigClient, set the given device as the default playback communication device
-                        client.SetDefaultEndpoint(DeviceCollection[i].ID, ERole.eCommunications);
+                        if (!playbackOnly.ToBool())
+                            client.SetDefaultEndpoint(DeviceCollection[i].ID, ERole.eCommunications);
                         // Using PolicyConfigClient, set the given device as the default playback device
                         client.SetDefaultEndpoint(DeviceCollection[i].ID, ERole.eMultimedia);
 
@@ -456,7 +468,8 @@ namespace AudioDeviceCmdlets
                         // Create a new audio PolicyConfigClient
                         PolicyConfigClient client = new PolicyConfigClient();
                         // Using PolicyConfigClient, set the given device as the default communication device (for its type)
-                        client.SetDefaultEndpoint(DeviceCollection[i].ID, ERole.eCommunications);
+                        if (!playbackOnly.ToBool())
+                            client.SetDefaultEndpoint(DeviceCollection[i].ID, ERole.eCommunications);
                         // Using PolicyConfigClient, set the given device as the default device (for its type)
                         client.SetDefaultEndpoint(DeviceCollection[i].ID, ERole.eMultimedia);
 
@@ -481,7 +494,8 @@ namespace AudioDeviceCmdlets
                     // Create a new audio PolicyConfigClient
                     PolicyConfigClient client = new PolicyConfigClient();
                     // Using PolicyConfigClient, set the given device as the default communication device (for its type)
-                    client.SetDefaultEndpoint(DeviceCollection[index.Value - 1].ID, ERole.eCommunications);
+                    if (!playbackOnly.ToBool())
+                        client.SetDefaultEndpoint(DeviceCollection[index.Value - 1].ID, ERole.eCommunications);
                     // Using PolicyConfigClient, set the given device as the default device (for its type)
                     client.SetDefaultEndpoint(DeviceCollection[index.Value - 1].ID, ERole.eMultimedia);
 

--- a/SOURCE/AudioDeviceCmdlets.cs
+++ b/SOURCE/AudioDeviceCmdlets.cs
@@ -419,9 +419,23 @@ namespace AudioDeviceCmdlets
         }
         private SwitchParameter playbackOnly;
 
+        // Parameter called to only set device as default communication and not default playback
+        [Parameter(Mandatory = false, ParameterSetName = "InputObject")]
+        [Parameter(Mandatory = false, ParameterSetName = "ID")]
+        [Parameter(Mandatory = false, ParameterSetName = "Index")]
+        public SwitchParameter CommunicationOnly
+        {
+            get { return communicationOnly; }
+            set { communicationOnly = value; }
+        }
+        private SwitchParameter communicationOnly;
+
         // Cmdlet execution
         protected override void ProcessRecord()
         {
+            if (playbackOnly.ToBool() && communicationOnly.ToBool())
+                throw new System.ArgumentException("Impossible to do both PlaybackOnly and CommunicatioOnly at the same time.");
+
             // Create a new MMDeviceEnumerator
             MMDeviceEnumerator DevEnum = new MMDeviceEnumerator();
             // Create a MMDeviceCollection of every devices that are enabled
@@ -442,7 +456,8 @@ namespace AudioDeviceCmdlets
                         if (!playbackOnly.ToBool())
                             client.SetDefaultEndpoint(DeviceCollection[i].ID, ERole.eCommunications);
                         // Using PolicyConfigClient, set the given device as the default playback device
-                        client.SetDefaultEndpoint(DeviceCollection[i].ID, ERole.eMultimedia);
+                        if (!communicationOnly.ToBool())
+                            client.SetDefaultEndpoint(DeviceCollection[i].ID, ERole.eMultimedia);
 
                         // Output the result of the creation of a new AudioDevice while assining it the an index, and the MMDevice itself, and a default value of true
                         WriteObject(new AudioDevice(i + 1, DeviceCollection[i], true));
@@ -471,7 +486,8 @@ namespace AudioDeviceCmdlets
                         if (!playbackOnly.ToBool())
                             client.SetDefaultEndpoint(DeviceCollection[i].ID, ERole.eCommunications);
                         // Using PolicyConfigClient, set the given device as the default device (for its type)
-                        client.SetDefaultEndpoint(DeviceCollection[i].ID, ERole.eMultimedia);
+                        if (!communicationOnly.ToBool())
+                            client.SetDefaultEndpoint(DeviceCollection[i].ID, ERole.eMultimedia);
 
                         // Output the result of the creation of a new AudioDevice while assining it the index, and the MMDevice itself, and a default value of true
                         WriteObject(new AudioDevice(i + 1, DeviceCollection[i], true));
@@ -497,7 +513,8 @@ namespace AudioDeviceCmdlets
                     if (!playbackOnly.ToBool())
                         client.SetDefaultEndpoint(DeviceCollection[index.Value - 1].ID, ERole.eCommunications);
                     // Using PolicyConfigClient, set the given device as the default device (for its type)
-                    client.SetDefaultEndpoint(DeviceCollection[index.Value - 1].ID, ERole.eMultimedia);
+                    if (!communicationOnly.ToBool())
+                        client.SetDefaultEndpoint(DeviceCollection[index.Value - 1].ID, ERole.eMultimedia);
 
                     // Output the result of the creation of a new AudioDevice while assining it the index, and the MMDevice itself, and a default value of true
                     WriteObject(new AudioDevice(index.Value, DeviceCollection[index.Value - 1], true));

--- a/SOURCE/AudioDeviceCmdlets.cs
+++ b/SOURCE/AudioDeviceCmdlets.cs
@@ -412,12 +412,12 @@ namespace AudioDeviceCmdlets
         [Parameter(Mandatory = false, ParameterSetName = "InputObject")]
         [Parameter(Mandatory = false, ParameterSetName = "ID")]
         [Parameter(Mandatory = false, ParameterSetName = "Index")]
-        public SwitchParameter PlaybackOnly
+        public SwitchParameter DefaultOnly
         {
-            get { return playbackOnly; }
-            set { playbackOnly = value; }
+            get { return defaultOnly; }
+            set { defaultOnly = value; }
         }
-        private SwitchParameter playbackOnly;
+        private SwitchParameter defaultOnly;
 
         // Parameter called to only set device as default communication and not default playback
         [Parameter(Mandatory = false, ParameterSetName = "InputObject")]
@@ -433,8 +433,8 @@ namespace AudioDeviceCmdlets
         // Cmdlet execution
         protected override void ProcessRecord()
         {
-            if (playbackOnly.ToBool() && communicationOnly.ToBool())
-                throw new System.ArgumentException("Impossible to do both PlaybackOnly and CommunicatioOnly at the same time.");
+            if (defaultOnly.ToBool() && communicationOnly.ToBool())
+                throw new System.ArgumentException("Impossible to do both DefaultOnly and CommunicatioOnly at the same time.");
 
             // Create a new MMDeviceEnumerator
             MMDeviceEnumerator DevEnum = new MMDeviceEnumerator();
@@ -453,7 +453,7 @@ namespace AudioDeviceCmdlets
                         // Create a new audio PolicyConfigClient
                         PolicyConfigClient client = new PolicyConfigClient();
                         // Using PolicyConfigClient, set the given device as the default playback communication device
-                        if (!playbackOnly.ToBool())
+                        if (!defaultOnly.ToBool())
                             client.SetDefaultEndpoint(DeviceCollection[i].ID, ERole.eCommunications);
                         // Using PolicyConfigClient, set the given device as the default playback device
                         if (!communicationOnly.ToBool())
@@ -483,7 +483,7 @@ namespace AudioDeviceCmdlets
                         // Create a new audio PolicyConfigClient
                         PolicyConfigClient client = new PolicyConfigClient();
                         // Using PolicyConfigClient, set the given device as the default communication device (for its type)
-                        if (!playbackOnly.ToBool())
+                        if (!defaultOnly.ToBool())
                             client.SetDefaultEndpoint(DeviceCollection[i].ID, ERole.eCommunications);
                         // Using PolicyConfigClient, set the given device as the default device (for its type)
                         if (!communicationOnly.ToBool())
@@ -510,7 +510,7 @@ namespace AudioDeviceCmdlets
                     // Create a new audio PolicyConfigClient
                     PolicyConfigClient client = new PolicyConfigClient();
                     // Using PolicyConfigClient, set the given device as the default communication device (for its type)
-                    if (!playbackOnly.ToBool())
+                    if (!defaultOnly.ToBool())
                         client.SetDefaultEndpoint(DeviceCollection[index.Value - 1].ID, ERole.eCommunications);
                     // Using PolicyConfigClient, set the given device as the default device (for its type)
                     if (!communicationOnly.ToBool())


### PR DESCRIPTION
These parameters provide an additional option to the AudioDevice/ID/Index parameters to only set default playback or communication device and not the other.
Very useful when you have headsets that have two audio devices, one for communication and one for normal playback.