### PR TITLE
Get devices from a try-catch

### DIFF
--- a/SOURCE/AudioDeviceCmdlets.cs
+++ b/SOURCE/AudioDeviceCmdlets.cs
@@ -71,13 +71,13 @@ namespace AudioDeviceCmdlets
     public class AudioDeviceCreationToolkit
     {
         // The MMDeviceEnumerator
-        public MMDeviceEnumerator DeviceEnumerator;
+        public MMDeviceEnumerator DevEnum;
 
         // To be created, a new AudioDeviceCreationToolkit needs a MMDeviceEnumerator it will use to compare the ID its methods receive
-        public AudioDeviceCreationToolkit(MMDeviceEnumerator DeviceEnumerator)
+        public AudioDeviceCreationToolkit(MMDeviceEnumerator DevEnum)
         {
             // Set this object's DeviceEnumerator to the received MMDeviceEnumerator
-            this.DeviceEnumerator = DeviceEnumerator;
+            this.DevEnum = DevEnum;
         }
 
         // Method to find out, in a collection of all enabled MMDevice, the Index of a MMDevice, given its ID
@@ -87,12 +87,12 @@ namespace AudioDeviceCmdlets
             MMDeviceCollection DeviceCollection = null;
             try
             {
-                DeviceCollection = DeviceEnumerator.EnumerateAudioEndPoints(EDataFlow.eAll, EDeviceState.DEVICE_STATE_ACTIVE);
+                DeviceCollection = DevEnum.EnumerateAudioEndPoints(EDataFlow.eAll, EDeviceState.DEVICE_STATE_ACTIVE);
             }
             catch
             {
                 // Error
-                throw new System.Exception("Error in AudioDeviceCreationToolkit.FindIndex(string ID) - Failed to create the collection of all enabled MMDevice using MMDeviceEnumerator");
+                throw new System.Exception("Error in method AudioDeviceCreationToolkit.FindIndex(string ID) - Failed to create the collection of all enabled MMDevice using MMDeviceEnumerator");
             }
 
             // For each device in the collection
@@ -107,7 +107,7 @@ namespace AudioDeviceCmdlets
             }
 
             // Error
-            throw new System.Exception("Error in AudioDeviceCreationToolkit.FindIndex(string ID) - No MMDevice with the given ID was found in the collection of all enabled MMDevice");
+            throw new System.Exception("Error in method AudioDeviceCreationToolkit.FindIndex(string ID) - No MMDevice with the given ID was found in the collection of all enabled MMDevice");
         }
 
         // Method to find out if a MMDevice is the default MMDevice of its type, given its ID
@@ -117,7 +117,7 @@ namespace AudioDeviceCmdlets
             string PlaybackID = "";
             try
             {
-                PlaybackID = (DeviceEnumerator.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eMultimedia)).ID;
+                PlaybackID = (DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eMultimedia)).ID;
             }
             catch { }
 
@@ -131,7 +131,7 @@ namespace AudioDeviceCmdlets
             string RecordingID = "";
             try
             {
-                RecordingID = (DeviceEnumerator.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eMultimedia)).ID;
+                RecordingID = (DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eMultimedia)).ID;
             }
             catch { }
 
@@ -151,7 +151,7 @@ namespace AudioDeviceCmdlets
             string PlaybackCommunicationID = "";
             try
             {
-                PlaybackCommunicationID = (DeviceEnumerator.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eCommunications)).ID;
+                PlaybackCommunicationID = (DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eCommunications)).ID;
             }
             catch { }
 
@@ -165,7 +165,7 @@ namespace AudioDeviceCmdlets
             string RecordingCommunicationID = "";
             try
             {
-                RecordingCommunicationID = (DeviceEnumerator.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eCommunications)).ID;
+                RecordingCommunicationID = (DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eCommunications)).ID;
             }
             catch { }
 
@@ -331,8 +331,17 @@ namespace AudioDeviceCmdlets
                 // Create a AudioDeviceCreationToolkit
                 AudioDeviceCreationToolkit Toolkit = new AudioDeviceCreationToolkit(DevEnum);
 
-                // Create a MMDeviceCollection of every devices that are enabled
-                MMDeviceCollection DeviceCollection = DevEnum.EnumerateAudioEndPoints(EDataFlow.eAll, EDeviceState.DEVICE_STATE_ACTIVE);
+                // Enumarate all enabled devices in a collection
+                MMDeviceCollection DeviceCollection = null;
+                try
+                {
+                    DeviceCollection = DevEnum.EnumerateAudioEndPoints(EDataFlow.eAll, EDeviceState.DEVICE_STATE_ACTIVE);
+                }
+                catch
+                {
+                    // Error
+                    throw new System.Exception("Error in parameter List - Failed to create the collection of all enabled MMDevice using MMDeviceEnumerator");
+                }
 
                 // For every MMDevice in DeviceCollection
                 for (int i = 0; i < DeviceCollection.Count; i++)
@@ -351,8 +360,17 @@ namespace AudioDeviceCmdlets
                 // Create a AudioDeviceCreationToolkit
                 AudioDeviceCreationToolkit Toolkit = new AudioDeviceCreationToolkit(DevEnum);
 
-                // Create a MMDeviceCollection of every devices that are enabled
-                MMDeviceCollection DeviceCollection = DevEnum.EnumerateAudioEndPoints(EDataFlow.eAll, EDeviceState.DEVICE_STATE_ACTIVE);
+                // Enumarate all enabled devices in a collection
+                MMDeviceCollection DeviceCollection = null;
+                try
+                {
+                    DeviceCollection = DevEnum.EnumerateAudioEndPoints(EDataFlow.eAll, EDeviceState.DEVICE_STATE_ACTIVE);
+                }
+                catch
+                {
+                    // Error
+                    throw new System.Exception("Error in parameter ID - Failed to create the collection of all enabled MMDevice using MMDeviceEnumerator");
+                }
 
                 // For every MMDevice in DeviceCollection
                 for (int i = 0; i < DeviceCollection.Count; i++)
@@ -378,8 +396,17 @@ namespace AudioDeviceCmdlets
                 // Create a AudioDeviceCreationToolkit
                 AudioDeviceCreationToolkit Toolkit = new AudioDeviceCreationToolkit(DevEnum);
 
-                // Create a MMDeviceCollection of every devices that are enabled
-                MMDeviceCollection DeviceCollection = DevEnum.EnumerateAudioEndPoints(EDataFlow.eAll, EDeviceState.DEVICE_STATE_ACTIVE);
+                // Enumarate all enabled devices in a collection
+                MMDeviceCollection DeviceCollection = null;
+                try
+                {
+                    DeviceCollection = DevEnum.EnumerateAudioEndPoints(EDataFlow.eAll, EDeviceState.DEVICE_STATE_ACTIVE);
+                }
+                catch
+                {
+                    // Error
+                    throw new System.Exception("Error in parameter Index - Failed to create the collection of all enabled MMDevice using MMDeviceEnumerator");
+                }
 
                 // If the Index is valid
                 if (index.Value >= 1 && index.Value <= DeviceCollection.Count)
@@ -853,8 +880,18 @@ namespace AudioDeviceCmdlets
 
             // Create a new MMDeviceEnumerator
             MMDeviceEnumerator DevEnum = new MMDeviceEnumerator();
-            // Create a MMDeviceCollection of every devices that are enabled
-            MMDeviceCollection DeviceCollection = DevEnum.EnumerateAudioEndPoints(EDataFlow.eAll, EDeviceState.DEVICE_STATE_ACTIVE);
+
+            // Enumarate all enabled devices in a collection
+            MMDeviceCollection DeviceCollection = null;
+            try
+            {
+                DeviceCollection = DevEnum.EnumerateAudioEndPoints(EDataFlow.eAll, EDeviceState.DEVICE_STATE_ACTIVE);
+            }
+            catch
+            {
+                // Error
+                throw new System.Exception("Error in cmdlet Set - Failed to create the collection of all enabled MMDevice using MMDeviceEnumerator");
+            }
 
             // If the InputObject parameter received a value
             if (inputObject != null)

--- a/SOURCE/AudioDeviceCmdlets.cs
+++ b/SOURCE/AudioDeviceCmdlets.cs
@@ -286,6 +286,32 @@ namespace AudioDeviceCmdlets
             // If the ID parameter received a value
             if (!string.IsNullOrEmpty(id))
             {
+                // Get the ID of the default device and the default communication device for both type
+                string DefaultPlaybackID = null;
+                string DefaultRecordingID = null;
+                string DefaultCommunicationPlaybackID = null;
+                string DefaultCommunicationRecordingID = null;
+                try
+                {
+                    DefaultPlaybackID = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eMultimedia).ID;
+                }
+                catch { }
+                try
+                {
+                    DefaultRecordingID = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eMultimedia).ID;
+                }
+                catch { }
+                try
+                {
+                    DefaultCommunicationPlaybackID = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eCommunications).ID;
+                }
+                catch { }
+                try
+                {
+                    DefaultCommunicationRecordingID = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eCommunications).ID;
+                }
+                catch { }
+
                 // For every MMDevice in DeviceCollection
                 for (int i = 0; i < DeviceCollection.Count; i++)
                 {
@@ -293,10 +319,10 @@ namespace AudioDeviceCmdlets
                     if (string.Compare(DeviceCollection[i].ID, id, System.StringComparison.CurrentCultureIgnoreCase) == 0)
                     {
                         // If this MMDevice's ID is either, the same as the default playback device's ID, or the same as the default recording device's ID
-                        if (DeviceCollection[i].ID == DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eMultimedia).ID || DeviceCollection[i].ID == DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eMultimedia).ID)
+                        if (DeviceCollection[i].ID == DefaultPlaybackID || DeviceCollection[i].ID == DefaultRecordingID)
                         {
                             // If the MMDevice's ID is either, the same as the default communication playback device's ID, or the same as the default communication recording device's ID
-                            if (DeviceCollection[i].ID == DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eCommunications).ID || DeviceCollection[i].ID == DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eCommunications).ID)
+                            if (DeviceCollection[i].ID == DefaultCommunicationPlaybackID || DeviceCollection[i].ID == DefaultCommunicationRecordingID)
                             {
                                 // Output the result of the creation of a new AudioDevice while assining it an index, and the MMDevice itself, a default value of true, and a default communication value of true
                                 WriteObject(new AudioDevice(i + 1, DeviceCollection[i], true, true));
@@ -310,7 +336,7 @@ namespace AudioDeviceCmdlets
                         else
                         {
                             // If the MMDevice's ID is either, the same as the default communication playback device's ID, or the same as the default communication recording device's ID
-                            if (DeviceCollection[i].ID == DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eCommunications).ID || DeviceCollection[i].ID == DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eCommunications).ID)
+                            if (DeviceCollection[i].ID == DefaultCommunicationPlaybackID || DeviceCollection[i].ID == DefaultCommunicationRecordingID)
                             {
                                 // Output the result of the creation of a new AudioDevice while assining it an index, and the MMDevice itself, a default value of false, and a default communication value of true
                                 WriteObject(new AudioDevice(i + 1, DeviceCollection[i], false, true));

--- a/SOURCE/AudioDeviceCmdlets.cs
+++ b/SOURCE/AudioDeviceCmdlets.cs
@@ -68,6 +68,7 @@ namespace AudioDeviceCmdlets
         }
     }
 
+    // Class to get information on a MMDevice towards the creation of a corresponding AudioDevice
     public class AudioDeviceCreationToolkit
     {
         // The MMDeviceEnumerator
@@ -86,7 +87,7 @@ namespace AudioDeviceCmdlets
             MMDeviceCollection DeviceCollection = null;
             try
             {
-                // Enumarate all enabled devices in a collection
+                // Enumerate all enabled devices in a collection
                 DeviceCollection = DevEnum.EnumerateAudioEndPoints(EDataFlow.eAll, EDeviceState.DEVICE_STATE_ACTIVE);
             }
             catch
@@ -334,7 +335,7 @@ namespace AudioDeviceCmdlets
                 MMDeviceCollection DeviceCollection = null;
                 try
                 {
-                    // Enumarate all enabled devices in a collection
+                    // Enumerate all enabled devices in a collection
                     DeviceCollection = DevEnum.EnumerateAudioEndPoints(EDataFlow.eAll, EDeviceState.DEVICE_STATE_ACTIVE);
                 }
                 catch
@@ -363,7 +364,7 @@ namespace AudioDeviceCmdlets
                 MMDeviceCollection DeviceCollection = null;
                 try
                 {
-                    // Enumarate all enabled devices in a collection
+                    // Enumerate all enabled devices in a collection
                     DeviceCollection = DevEnum.EnumerateAudioEndPoints(EDataFlow.eAll, EDeviceState.DEVICE_STATE_ACTIVE);
                 }
                 catch
@@ -399,7 +400,7 @@ namespace AudioDeviceCmdlets
                 MMDeviceCollection DeviceCollection = null;
                 try
                 {
-                    // Enumarate all enabled devices in a collection
+                    // Enumerate all enabled devices in a collection
                     DeviceCollection = DevEnum.EnumerateAudioEndPoints(EDataFlow.eAll, EDeviceState.DEVICE_STATE_ACTIVE);
                 }
                 catch
@@ -884,7 +885,7 @@ namespace AudioDeviceCmdlets
             MMDeviceCollection DeviceCollection = null;
             try
             {
-                // Enumarate all enabled devices in a collection
+                // Enumerate all enabled devices in a collection
                 DeviceCollection = DevEnum.EnumerateAudioEndPoints(EDataFlow.eAll, EDeviceState.DEVICE_STATE_ACTIVE);
             }
             catch

--- a/SOURCE/AudioDeviceCmdlets.cs
+++ b/SOURCE/AudioDeviceCmdlets.cs
@@ -1104,85 +1104,181 @@ namespace AudioDeviceCmdlets
             // If the PlaybackCommunicationMute parameter received a value
             if (playbackcommunicationmute != null)
             {
-                // Set the mute state of the default communication playback device to that of the boolean value received by the Cmdlet
-                DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eCommunications).AudioEndpointVolume.Mute = (bool)playbackcommunicationmute;
+                try
+                {
+                    // Set the mute state of the default communication playback device to that of the boolean value received by the Cmdlet
+                    DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eCommunications).AudioEndpointVolume.Mute = (bool)playbackcommunicationmute;
+                }
+                catch
+                {
+                    // Throw an exception about the device not being found
+                    throw new System.ArgumentException("No playback AudioDevice found with the default communication role");
+                }                
             }
 
             // If the PlaybackCommunicationMuteToggle parameter was called
             if (playbackcommunicationmutetoggle)
             {
-                // Toggle the mute state of the default communication playback device
-                DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eCommunications).AudioEndpointVolume.Mute = !DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eCommunications).AudioEndpointVolume.Mute;
+                try
+                {
+                    // Toggle the mute state of the default communication playback device
+                    DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eCommunications).AudioEndpointVolume.Mute = !DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eCommunications).AudioEndpointVolume.Mute;
+                }
+                catch
+                {
+                    // Throw an exception about the device not being found
+                    throw new System.ArgumentException("No playback AudioDevice found with the default communication role");
+                }
             }
 
             // If the PlaybackCommunicationVolume parameter received a value
             if(playbackcommunicationvolume != null)
             {
-                // Set the volume level of the default communication playback device to that of the float value received by the PlaybackCommunicationVolume parameter
-                DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eCommunications).AudioEndpointVolume.MasterVolumeLevelScalar = (float)playbackcommunicationvolume / 100.0f;
+                try
+                {
+                    // Set the volume level of the default communication playback device to that of the float value received by the PlaybackCommunicationVolume parameter
+                    DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eCommunications).AudioEndpointVolume.MasterVolumeLevelScalar = (float)playbackcommunicationvolume / 100.0f;
+                }
+                catch
+                {
+                    // Throw an exception about the device not being found
+                    throw new System.ArgumentException("No playback AudioDevice found with the default communication role");
+                }
             }
 
             // If the PlaybackMute parameter received a value
             if (playbackmute != null)
             {
-                // Set the mute state of the default playback device to that of the boolean value received by the Cmdlet
-                DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eMultimedia).AudioEndpointVolume.Mute = (bool)playbackmute;
+                try
+                {
+                    // Set the mute state of the default playback device to that of the boolean value received by the Cmdlet
+                    DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eMultimedia).AudioEndpointVolume.Mute = (bool)playbackmute;
+                }
+                catch
+                {
+                    // Throw an exception about the device not being found
+                    throw new System.ArgumentException("No playback AudioDevice found with the default role");
+                }
             }
 
             // If the PlaybackMuteToggle parameter was called
             if (playbackmutetoggle)
             {
-                // Toggle the mute state of the default playback device
-                DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eMultimedia).AudioEndpointVolume.Mute = !DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eMultimedia).AudioEndpointVolume.Mute;
+                try
+                {
+                    // Toggle the mute state of the default playback device
+                    DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eMultimedia).AudioEndpointVolume.Mute = !DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eMultimedia).AudioEndpointVolume.Mute;
+                }
+                catch
+                {
+                    // Throw an exception about the device not being found
+                    throw new System.ArgumentException("No playback AudioDevice found with the default role");
+                }
             }
 
             // If the PlaybackVolume parameter received a value
             if(playbackvolume != null)
             {
-                // Set the volume level of the default playback device to that of the float value received by the PlaybackVolume parameter
-                DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eMultimedia).AudioEndpointVolume.MasterVolumeLevelScalar = (float)playbackvolume / 100.0f;
+                try
+                {
+                    // Set the volume level of the default playback device to that of the float value received by the PlaybackVolume parameter
+                    DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eMultimedia).AudioEndpointVolume.MasterVolumeLevelScalar = (float)playbackvolume / 100.0f;
+                }
+                catch
+                {
+                    // Throw an exception about the device not being found
+                    throw new System.ArgumentException("No playback AudioDevice found with the default role");
+                }
             }
 
             // If the RecordingCommunicationMute parameter received a value
             if (recordingcommunicationmute != null)
             {
-                // Set the mute state of the default communication recording device to that of the boolean value received by the Cmdlet
-                DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eCommunications).AudioEndpointVolume.Mute = (bool)recordingcommunicationmute;
+                try
+                {
+                    // Set the mute state of the default communication recording device to that of the boolean value received by the Cmdlet
+                    DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eCommunications).AudioEndpointVolume.Mute = (bool)recordingcommunicationmute;
+                }
+                catch
+                {
+                    // Throw an exception about the device not being found
+                    throw new System.ArgumentException("No recording AudioDevice found with the default communication role");
+                }
             }
 
             // If the RecordingCommunicationMuteToggle parameter was called
             if (recordingcommunicationmutetoggle)
             {
-                // Toggle the mute state of the default communication recording device
-                DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eCommunications).AudioEndpointVolume.Mute = !DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eCommunications).AudioEndpointVolume.Mute;
+                try
+                {
+                    // Toggle the mute state of the default communication recording device
+                    DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eCommunications).AudioEndpointVolume.Mute = !DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eCommunications).AudioEndpointVolume.Mute;
+                }
+                catch
+                {
+                    // Throw an exception about the device not being found
+                    throw new System.ArgumentException("No recording AudioDevice found with the default communication role");
+                }
             }
 
             // If the RecordingCommunicationVolume parameter received a value
             if (recordingcommunicationvolume != null)
             {
-                // Set the volume level of the default communication recording device to that of the float value received by the RecordingCommunicationVolume parameter
-                DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eCommunications).AudioEndpointVolume.MasterVolumeLevelScalar = (float)recordingcommunicationvolume / 100.0f;
+                try
+                {
+                    // Set the volume level of the default communication recording device to that of the float value received by the RecordingCommunicationVolume parameter
+                    DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eCommunications).AudioEndpointVolume.MasterVolumeLevelScalar = (float)recordingcommunicationvolume / 100.0f;
+                }
+                catch
+                {
+                    // Throw an exception about the device not being found
+                    throw new System.ArgumentException("No recording AudioDevice found with the default communication role");
+                }
             }
 
             // If the RecordingMute parameter received a value
             if (recordingmute != null)
             {
-                // Set the mute state of the default recording device to that of the boolean value received by the Cmdlet
-                DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eMultimedia).AudioEndpointVolume.Mute = (bool)recordingmute;
+                try
+                {
+                    // Set the mute state of the default recording device to that of the boolean value received by the Cmdlet
+                    DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eMultimedia).AudioEndpointVolume.Mute = (bool)recordingmute;
+                }
+                catch
+                {
+                    // Throw an exception about the device not being found
+                    throw new System.ArgumentException("No recording AudioDevice found with the default role");
+                }
             }
 
             // If the RecordingMuteToggle parameter was called
             if (recordingmutetoggle)
             {
-                // Toggle the mute state of the default recording device
-                DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eMultimedia).AudioEndpointVolume.Mute = !DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eMultimedia).AudioEndpointVolume.Mute;
+                try
+                {
+                    // Toggle the mute state of the default recording device
+                    DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eMultimedia).AudioEndpointVolume.Mute = !DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eMultimedia).AudioEndpointVolume.Mute;
+                }
+                catch
+                {
+                    // Throw an exception about the device not being found
+                    throw new System.ArgumentException("No recording AudioDevice found with the default role");
+                }
             }
 
             // If the RecordingVolume parameter received a value
             if (recordingvolume != null)
             {
-                // Set the volume level of the default recording device to that of the float value received by the RecordingVolume parameter
-                DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eMultimedia).AudioEndpointVolume.MasterVolumeLevelScalar = (float)recordingvolume / 100.0f;
+                try
+                {
+                    // Set the volume level of the default recording device to that of the float value received by the RecordingVolume parameter
+                    DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eMultimedia).AudioEndpointVolume.MasterVolumeLevelScalar = (float)recordingvolume / 100.0f;
+                }
+                catch
+                {
+                    // Throw an exception about the device not being found
+                    throw new System.ArgumentException("No recording AudioDevice found with the default role");
+                }
             }
         }
     }

--- a/SOURCE/AudioDeviceCmdlets.cs
+++ b/SOURCE/AudioDeviceCmdlets.cs
@@ -219,14 +219,40 @@ namespace AudioDeviceCmdlets
             // If the List switch parameter was called
             if (list)
             {
+                // Get the ID of the default device and the default communication device for both type
+                string DefaultPlaybackID = null;
+                string DefaultRecordingID = null;
+                string DefaultCommunicationPlaybackID = null;
+                string DefaultCommunicationRecordingID = null;
+                try
+                {
+                    DefaultPlaybackID = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eMultimedia).ID;
+                }
+                catch { }
+                try
+                {
+                    DefaultRecordingID = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eMultimedia).ID;
+                }
+                catch { }
+                try
+                {
+                    DefaultCommunicationPlaybackID = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eCommunications).ID;
+                }
+                catch { }
+                try
+                {
+                    DefaultCommunicationRecordingID = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eCommunications).ID;
+                }
+                catch { }
+
                 // For every MMDevice in DeviceCollection
                 for (int i = 0; i < DeviceCollection.Count; i++)
                 {
                     // If this MMDevice's ID is either, the same as the default playback device's ID, or the same as the default recording device's ID
-                    if (DeviceCollection[i].ID == DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eMultimedia).ID || DeviceCollection[i].ID == DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eMultimedia).ID)
+                    if (DeviceCollection[i].ID == DefaultPlaybackID || DeviceCollection[i].ID == DefaultRecordingID)
                     {
                         // If the MMDevice's ID is either, the same as the default communication playback device's ID, or the same as the default communication recording device's ID
-                        if (DeviceCollection[i].ID == DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eCommunications).ID || DeviceCollection[i].ID == DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eCommunications).ID)
+                        if (DeviceCollection[i].ID == DefaultCommunicationPlaybackID || DeviceCollection[i].ID == DefaultCommunicationRecordingID)
                         {
                             // Output the result of the creation of a new AudioDevice while assining it an index, and the MMDevice itself, a default value of true, and a default communication value of true
                             WriteObject(new AudioDevice(i + 1, DeviceCollection[i], true, true));
@@ -240,7 +266,7 @@ namespace AudioDeviceCmdlets
                     else
                     {
                         // If the MMDevice's ID is either, the same as the default communication playback device's ID, or the same as the default communication recording device's ID
-                        if (DeviceCollection[i].ID == DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eCommunications).ID || DeviceCollection[i].ID == DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eCommunications).ID)
+                        if (DeviceCollection[i].ID == DefaultCommunicationPlaybackID || DeviceCollection[i].ID == DefaultCommunicationRecordingID)
                         {
                             // Output the result of the creation of a new AudioDevice while assining it an index, and the MMDevice itself, a default value of false, and a default communication value of true
                             WriteObject(new AudioDevice(i + 1, DeviceCollection[i], false, true));

--- a/SOURCE/AudioDeviceCmdlets.cs
+++ b/SOURCE/AudioDeviceCmdlets.cs
@@ -1368,16 +1368,44 @@ namespace AudioDeviceCmdlets
             // If the PlaybackCommunicationMeter parameter was called
             if (playbackcommunicationmeter)
             {
+                // Get the name of the default communication playback device
+                string FriendlyName = null;
+                try
+                {
+                    FriendlyName = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eCommunications).FriendlyName;
+                }
+                catch
+                {
+                    // Throw an exception about the device not being found
+                    throw new System.ArgumentException("No playback AudioDevice found with the default communication role");
+                }
                 // Create a new progress bar to output current audiometer result of the default communication playback device
-                ProgressRecord pr = new ProgressRecord(0, DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eCommunications).FriendlyName, "Peak Value");
+                ProgressRecord pr = new ProgressRecord(0, FriendlyName, "Peak Value");
+
                 // Set the progress bar to zero
                 pr.PercentComplete = 0;
 
                 // Loop until interruption ex: CTRL+C
                 do
                 {
+                    // Get the name of the default communication playback device
+                    // Get current audio meter master peak value
+                    float MasterPeakValue;
+                    try
+                    {
+                        FriendlyName = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eCommunications).FriendlyName;
+                        MasterPeakValue = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eCommunications).AudioMeterInformation.MasterPeakValue;
+                    }
+                    catch
+                    {
+                        // Throw an exception about the device not being found
+                        throw new System.ArgumentException("No playback AudioDevice found with the default communication role");
+                    }
+                    // Set progress bar title
+                    pr.Activity = FriendlyName;
+
                     // Set progress bar to current audiometer result
-                    pr.PercentComplete = System.Convert.ToInt32(DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eCommunications).AudioMeterInformation.MasterPeakValue * 100);
+                    pr.PercentComplete = System.Convert.ToInt32(MasterPeakValue * 100);
 
                     // Write current audiometer result as a progress bar
                     WriteProgress(pr);
@@ -1395,9 +1423,20 @@ namespace AudioDeviceCmdlets
                 // Loop until interruption ex: CTRL+C
                 do
                 {
+                    // Get current audio meter master peak value
+                    float MasterPeakValue;
+                    try
+                    {
+                        MasterPeakValue = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eCommunications).AudioMeterInformation.MasterPeakValue;
+                    }
+                    catch
+                    {
+                        // Throw an exception about the device not being found
+                        throw new System.ArgumentException("No playback AudioDevice found with the default communication role");
+                    }
                     // Write current audiometer result as a value
-                    WriteObject(System.Convert.ToInt32(DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eCommunications).AudioMeterInformation.MasterPeakValue * 100));
-
+                    WriteObject(System.Convert.ToInt32(MasterPeakValue * 100));
+                    
                     // Wait 100 milliseconds
                     System.Threading.Thread.Sleep(100);
                 }
@@ -1408,16 +1447,44 @@ namespace AudioDeviceCmdlets
             // If the PlaybackMeter parameter was called
             if (playbackmeter)
             {
+                // Get the name of the default playback device
+                string FriendlyName = null;
+                try
+                {
+                    FriendlyName = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eMultimedia).FriendlyName;
+                }
+                catch
+                {
+                    // Throw an exception about the device not being found
+                    throw new System.ArgumentException("No playback AudioDevice found with the default role");
+                }
                 // Create a new progress bar to output current audiometer result of the default playback device
-                ProgressRecord pr = new ProgressRecord(0, DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eMultimedia).FriendlyName, "Peak Value");
+                ProgressRecord pr = new ProgressRecord(0, FriendlyName, "Peak Value");
+
                 // Set the progress bar to zero
                 pr.PercentComplete = 0;
 
                 // Loop until interruption ex: CTRL+C
                 do
                 {
+                    // Get the name of the default playback device
+                    // Get current audio meter master peak value
+                    float MasterPeakValue;
+                    try
+                    {
+                        FriendlyName = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eMultimedia).FriendlyName;
+                        MasterPeakValue = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eMultimedia).AudioMeterInformation.MasterPeakValue;
+                    }
+                    catch
+                    {
+                        // Throw an exception about the device not being found
+                        throw new System.ArgumentException("No playback AudioDevice found with the default role");
+                    }
+                    // Set progress bar title
+                    pr.Activity = FriendlyName;
+
                     // Set progress bar to current audiometer result
-                    pr.PercentComplete = System.Convert.ToInt32(DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eMultimedia).AudioMeterInformation.MasterPeakValue * 100);
+                    pr.PercentComplete = System.Convert.ToInt32(MasterPeakValue * 100);
 
                     // Write current audiometer result as a progress bar
                     WriteProgress(pr);
@@ -1435,8 +1502,19 @@ namespace AudioDeviceCmdlets
                 // Loop until interruption ex: CTRL+C
                 do
                 {
+                    // Get current audio meter master peak value
+                    float MasterPeakValue;
+                    try
+                    {
+                        MasterPeakValue = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eMultimedia).AudioMeterInformation.MasterPeakValue;
+                    }
+                    catch
+                    {
+                        // Throw an exception about the device not being found
+                        throw new System.ArgumentException("No playback AudioDevice found with the default role");
+                    }
                     // Write current audiometer result as a value
-                    WriteObject(System.Convert.ToInt32(DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eMultimedia).AudioMeterInformation.MasterPeakValue * 100));
+                    WriteObject(System.Convert.ToInt32(MasterPeakValue * 100));
 
                     // Wait 100 milliseconds
                     System.Threading.Thread.Sleep(100);
@@ -1448,16 +1526,44 @@ namespace AudioDeviceCmdlets
             // If the RecordingCommunicationMeter parameter was called
             if (recordingcommunicationmeter)
             {
+                // Get the name of the default communication recording device
+                string FriendlyName = null;
+                try
+                {
+                    FriendlyName = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eCommunications).FriendlyName;
+                }
+                catch
+                {
+                    // Throw an exception about the device not being found
+                    throw new System.ArgumentException("No recording AudioDevice found with the default communication role");
+                }
                 // Create a new progress bar to output current audiometer result of the default communication recording device
-                ProgressRecord pr = new ProgressRecord(0, DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eCommunications).FriendlyName, "Peak Value");
+                ProgressRecord pr = new ProgressRecord(0, FriendlyName, "Peak Value");
+
                 // Set the progress bar to zero
                 pr.PercentComplete = 0;
 
                 // Loop until interruption ex: CTRL+C
                 do
                 {
+                    // Get the name of the default communication recording device
+                    // Get current audio meter master peak value
+                    float MasterPeakValue;
+                    try
+                    {
+                        FriendlyName = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eCommunications).FriendlyName;
+                        MasterPeakValue = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eCommunications).AudioMeterInformation.MasterPeakValue;
+                    }
+                    catch
+                    {
+                        // Throw an exception about the device not being found
+                        throw new System.ArgumentException("No recording AudioDevice found with the default communication role");
+                    }
+                    // Set progress bar title
+                    pr.Activity = FriendlyName;
+
                     // Set progress bar to current audiometer result
-                    pr.PercentComplete = System.Convert.ToInt32(DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eCommunications).AudioMeterInformation.MasterPeakValue * 100);
+                    pr.PercentComplete = System.Convert.ToInt32(MasterPeakValue * 100);
 
                     // Write current audiometer result as a progress bar
                     WriteProgress(pr);
@@ -1475,8 +1581,19 @@ namespace AudioDeviceCmdlets
                 // Loop until interruption ex: CTRL+C
                 do
                 {
+                    // Get current audio meter master peak value
+                    float MasterPeakValue;
+                    try
+                    {
+                        MasterPeakValue = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eCommunications).AudioMeterInformation.MasterPeakValue;
+                    }
+                    catch
+                    {
+                        // Throw an exception about the device not being found
+                        throw new System.ArgumentException("No recording AudioDevice found with the default communication role");
+                    }
                     // Write current audiometer result as a value
-                    WriteObject(System.Convert.ToInt32(DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eCommunications).AudioMeterInformation.MasterPeakValue * 100));
+                    WriteObject(System.Convert.ToInt32(MasterPeakValue * 100));
 
                     // Wait 100 milliseconds
                     System.Threading.Thread.Sleep(100);
@@ -1488,16 +1605,44 @@ namespace AudioDeviceCmdlets
             // If the RecordingMeter parameter was called
             if (recordingmeter)
             {
+                // Get the name of the default recording device
+                string FriendlyName = null;
+                try
+                {
+                    FriendlyName = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eMultimedia).FriendlyName;
+                }
+                catch
+                {
+                    // Throw an exception about the device not being found
+                    throw new System.ArgumentException("No recording AudioDevice found with the default role");
+                }
                 // Create a new progress bar to output current audiometer result of the default recording device
-                ProgressRecord pr = new ProgressRecord(0, DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eMultimedia).FriendlyName, "Peak Value");
+                ProgressRecord pr = new ProgressRecord(0, FriendlyName, "Peak Value");
+
                 // Set the progress bar to zero
                 pr.PercentComplete = 0;
 
                 // Loop until interruption ex: CTRL+C
                 do
                 {
+                    // Get the name of the default recording device
+                    // Get current audio meter master peak value
+                    float MasterPeakValue;
+                    try
+                    {
+                        FriendlyName = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eMultimedia).FriendlyName;
+                        MasterPeakValue = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eMultimedia).AudioMeterInformation.MasterPeakValue;
+                    }
+                    catch
+                    {
+                        // Throw an exception about the device not being found
+                        throw new System.ArgumentException("No recording AudioDevice found with the default role");
+                    }
+                    // Set progress bar title
+                    pr.Activity = FriendlyName;
+
                     // Set progress bar to current audiometer result
-                    pr.PercentComplete = System.Convert.ToInt32(DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eMultimedia).AudioMeterInformation.MasterPeakValue * 100);
+                    pr.PercentComplete = System.Convert.ToInt32(MasterPeakValue * 100);
 
                     // Write current audiometer result as a progress bar
                     WriteProgress(pr);
@@ -1515,8 +1660,19 @@ namespace AudioDeviceCmdlets
                 // Loop until interruption ex: CTRL+C
                 do
                 {
+                    // Get current audio meter master peak value
+                    float MasterPeakValue;
+                    try
+                    {
+                        MasterPeakValue = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eMultimedia).AudioMeterInformation.MasterPeakValue;
+                    }
+                    catch
+                    {
+                        // Throw an exception about the device not being found
+                        throw new System.ArgumentException("No recording AudioDevice found with the default role");
+                    }
                     // Write current audiometer result as a value
-                    WriteObject(System.Convert.ToInt32(DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eMultimedia).AudioMeterInformation.MasterPeakValue * 100));
+                    WriteObject(System.Convert.ToInt32(MasterPeakValue * 100));
 
                     // Wait 100 milliseconds
                     System.Threading.Thread.Sleep(100);

--- a/SOURCE/AudioDeviceCmdlets.cs
+++ b/SOURCE/AudioDeviceCmdlets.cs
@@ -902,44 +902,56 @@ namespace AudioDeviceCmdlets
                     // If this MMDevice's ID is the same as the ID of the MMDevice received by the InputObject parameter
                     if (DeviceCollection[i].ID == inputObject.ID)
                     {
+                        // To use during creation of corresponding AudioDevice, assuming it is impossible to do both DefaultOnly and CommunicatioOnly at the same time
+                        bool DefaultState;
+                        bool CommunicationState;
+
                         // Create a new audio PolicyConfigClient
                         PolicyConfigClient client = new PolicyConfigClient();
-                        // Using PolicyConfigClient, set the given device as the default communication device (for its type)
-                        if (!defaultOnly.ToBool())
-                            client.SetDefaultEndpoint(DeviceCollection[i].ID, ERole.eCommunications);
-                        // Using PolicyConfigClient, set the given device as the default device (for its type)
-                        if (!communicationOnly.ToBool())
-                            client.SetDefaultEndpoint(DeviceCollection[i].ID, ERole.eMultimedia);
 
-                        // If this MMDevice's ID is either, the same as the default playback device's ID, or the same as the default recording device's ID
-                        if (DeviceCollection[i].ID == DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eMultimedia).ID || DeviceCollection[i].ID == DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eMultimedia).ID)
+                        // Create a AudioDeviceCreationToolkit
+                        AudioDeviceCreationToolkit Toolkit = new AudioDeviceCreationToolkit(DevEnum);
+
+                        // Unless the DefaultOnly parameter was called
+                        if (!defaultOnly.ToBool())
                         {
-                            // If the MMDevice's ID is either, the same as the default communication playback device's ID, or the same as the default communication recording device's ID
-                            if (DeviceCollection[i].ID == DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eCommunications).ID || DeviceCollection[i].ID == DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eCommunications).ID)
-                            {
-                                // Output the result of the creation of a new AudioDevice while assining it an index, and the MMDevice itself, a default value of true, and a default communication value of true
-                                WriteObject(new AudioDevice(i + 1, DeviceCollection[i], true, true));
-                            }
-                            else
-                            {
-                                // Output the result of the creation of a new AudioDevice while assining it an index, and the MMDevice itself, a default value of true, and a default communication value of false
-                                WriteObject(new AudioDevice(i + 1, DeviceCollection[i], true, false));
-                            }
+                            // The DefaultOnly parameter was not called
+
+                            // Using PolicyConfigClient, set the given device as the default communication device (for its type)
+                            client.SetDefaultEndpoint(DeviceCollection[i].ID, ERole.eCommunications);
+
+                            // Set default communication state to use
+                            CommunicationState = true;
                         }
                         else
                         {
-                            // If the MMDevice's ID is either, the same as the default communication playback device's ID, or the same as the default communication recording device's ID
-                            if (DeviceCollection[i].ID == DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eCommunications).ID || DeviceCollection[i].ID == DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eCommunications).ID)
-                            {
-                                // Output the result of the creation of a new AudioDevice while assining it an index, and the MMDevice itself, a default value of false, and a default communication value of true
-                                WriteObject(new AudioDevice(i + 1, DeviceCollection[i], false, true));
-                            }
-                            else
-                            {
-                                // Output the result of the creation of a new AudioDevice while assining it an index, and the MMDevice itself, a default value of false, and a default communication value of false
-                                WriteObject(new AudioDevice(i + 1, DeviceCollection[i], false, false));
-                            }
+                            // The DefaultOnly parameter was called
+
+                            // Set default communication state to use
+                            CommunicationState = Toolkit.IsDefaultCommunication(DeviceCollection[i].ID);
                         }
+
+                        // Unless the CommunicationOnly parameter was called
+                        if (!communicationOnly.ToBool())
+                        {
+                            // The CommunicationOnly parameter was not called
+
+                            // Using PolicyConfigClient, set the given device as the default device (for its type)
+                            client.SetDefaultEndpoint(DeviceCollection[i].ID, ERole.eMultimedia);
+
+                            // Set default state to use
+                            DefaultState = true;
+                        }
+                        else
+                        {
+                            // The CommunicationOnly parameter was called
+
+                            // Set default state to use
+                            DefaultState = Toolkit.IsDefault(DeviceCollection[i].ID);
+                        }
+
+                        // Output the result of the creation of a new AudioDevice, while assining it its index, the MMDevice itself, its default state, and its default communication state
+                        WriteObject(new AudioDevice(i + 1, DeviceCollection[i], DefaultState, CommunicationState));
 
                         // Stop checking for other parameters
                         return;
@@ -959,44 +971,56 @@ namespace AudioDeviceCmdlets
                     // If this MMDevice's ID is the same as the string received by the ID parameter
                     if (string.Compare(DeviceCollection[i].ID, id, System.StringComparison.CurrentCultureIgnoreCase) == 0)
                     {
+                        // To use during creation of corresponding AudioDevice, assuming it is impossible to do both DefaultOnly and CommunicatioOnly at the same time
+                        bool DefaultState;
+                        bool CommunicationState;
+
                         // Create a new audio PolicyConfigClient
                         PolicyConfigClient client = new PolicyConfigClient();
-                        // Using PolicyConfigClient, set the given device as the default communication device (for its type)
-                        if (!defaultOnly.ToBool())
-                            client.SetDefaultEndpoint(DeviceCollection[i].ID, ERole.eCommunications);
-                        // Using PolicyConfigClient, set the given device as the default device (for its type)
-                        if (!communicationOnly.ToBool())
-                            client.SetDefaultEndpoint(DeviceCollection[i].ID, ERole.eMultimedia);
 
-                        // If this MMDevice's ID is either, the same as the default playback device's ID, or the same as the default recording device's ID
-                        if (DeviceCollection[i].ID == DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eMultimedia).ID || DeviceCollection[i].ID == DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eMultimedia).ID)
+                        // Create a AudioDeviceCreationToolkit
+                        AudioDeviceCreationToolkit Toolkit = new AudioDeviceCreationToolkit(DevEnum);
+
+                        // Unless the DefaultOnly parameter was called
+                        if (!defaultOnly.ToBool())
                         {
-                            // If the MMDevice's ID is either, the same as the default communication playback device's ID, or the same as the default communication recording device's ID
-                            if (DeviceCollection[i].ID == DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eCommunications).ID || DeviceCollection[i].ID == DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eCommunications).ID)
-                            {
-                                // Output the result of the creation of a new AudioDevice while assining it an index, and the MMDevice itself, a default value of true, and a default communication value of true
-                                WriteObject(new AudioDevice(i + 1, DeviceCollection[i], true, true));
-                            }
-                            else
-                            {
-                                // Output the result of the creation of a new AudioDevice while assining it an index, and the MMDevice itself, a default value of true, and a default communication value of false
-                                WriteObject(new AudioDevice(i + 1, DeviceCollection[i], true, false));
-                            }
+                            // The DefaultOnly parameter was not called
+
+                            // Using PolicyConfigClient, set the given device as the default communication device (for its type)
+                            client.SetDefaultEndpoint(DeviceCollection[i].ID, ERole.eCommunications);
+
+                            // Set default communication state to use
+                            CommunicationState = true;
                         }
                         else
                         {
-                            // If the MMDevice's ID is either, the same as the default communication playback device's ID, or the same as the default communication recording device's ID
-                            if (DeviceCollection[i].ID == DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eCommunications).ID || DeviceCollection[i].ID == DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eCommunications).ID)
-                            {
-                                // Output the result of the creation of a new AudioDevice while assining it an index, and the MMDevice itself, a default value of false, and a default communication value of true
-                                WriteObject(new AudioDevice(i + 1, DeviceCollection[i], false, true));
-                            }
-                            else
-                            {
-                                // Output the result of the creation of a new AudioDevice while assining it an index, and the MMDevice itself, a default value of false, and a default communication value of false
-                                WriteObject(new AudioDevice(i + 1, DeviceCollection[i], false, false));
-                            }
+                            // The DefaultOnly parameter was called
+
+                            // Set default communication state to use
+                            CommunicationState = Toolkit.IsDefaultCommunication(DeviceCollection[i].ID);
                         }
+
+                        // Unless the CommunicationOnly parameter was called
+                        if (!communicationOnly.ToBool())
+                        {
+                            // The CommunicationOnly parameter was not called
+
+                            // Using PolicyConfigClient, set the given device as the default device (for its type)
+                            client.SetDefaultEndpoint(DeviceCollection[i].ID, ERole.eMultimedia);
+
+                            // Set default state to use
+                            DefaultState = true;
+                        }
+                        else
+                        {
+                            // The CommunicationOnly parameter was called
+
+                            // Set default state to use
+                            DefaultState = Toolkit.IsDefault(DeviceCollection[i].ID);
+                        }
+
+                        // Output the result of the creation of a new AudioDevice, while assining it its index, the MMDevice itself, its default state, and its default communication state
+                        WriteObject(new AudioDevice(i + 1, DeviceCollection[i], DefaultState, CommunicationState));
 
                         // Stop checking for other parameters
                         return;
@@ -1016,44 +1040,56 @@ namespace AudioDeviceCmdlets
                     // Use valid Index as iterative
                     int i = index.Value - 1;
 
+                    // To use during creation of corresponding AudioDevice, assuming it is impossible to do both DefaultOnly and CommunicatioOnly at the same time
+                    bool DefaultState;
+                    bool CommunicationState;
+
                     // Create a new audio PolicyConfigClient
                     PolicyConfigClient client = new PolicyConfigClient();
-                    // Using PolicyConfigClient, set the given device as the default communication device (for its type)
-                    if (!defaultOnly.ToBool())
-                        client.SetDefaultEndpoint(DeviceCollection[index.Value - 1].ID, ERole.eCommunications);
-                    // Using PolicyConfigClient, set the given device as the default device (for its type)
-                    if (!communicationOnly.ToBool())
-                        client.SetDefaultEndpoint(DeviceCollection[index.Value - 1].ID, ERole.eMultimedia);
 
-                    // If this MMDevice's ID is either, the same as the default playback device's ID, or the same as the default recording device's ID
-                    if (DeviceCollection[i].ID == DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eMultimedia).ID || DeviceCollection[i].ID == DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eMultimedia).ID)
+                    // Create a AudioDeviceCreationToolkit
+                    AudioDeviceCreationToolkit Toolkit = new AudioDeviceCreationToolkit(DevEnum);
+
+                    // Unless the DefaultOnly parameter was called
+                    if (!defaultOnly.ToBool())
                     {
-                        // If the MMDevice's ID is either, the same as the default communication playback device's ID, or the same as the default communication recording device's ID
-                        if (DeviceCollection[i].ID == DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eCommunications).ID || DeviceCollection[i].ID == DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eCommunications).ID)
-                        {
-                            // Output the result of the creation of a new AudioDevice while assining it an index, and the MMDevice itself, a default value of true, and a default communication value of true
-                            WriteObject(new AudioDevice(i + 1, DeviceCollection[i], true, true));
-                        }
-                        else
-                        {
-                            // Output the result of the creation of a new AudioDevice while assining it an index, and the MMDevice itself, a default value of true, and a default communication value of false
-                            WriteObject(new AudioDevice(i + 1, DeviceCollection[i], true, false));
-                        }
+                        // The DefaultOnly parameter was not called
+
+                        // Using PolicyConfigClient, set the given device as the default communication device (for its type)
+                        client.SetDefaultEndpoint(DeviceCollection[i].ID, ERole.eCommunications);
+
+                        // Set default communication state to use
+                        CommunicationState = true;
                     }
                     else
                     {
-                        // If the MMDevice's ID is either, the same as the default communication playback device's ID, or the same as the default communication recording device's ID
-                        if (DeviceCollection[i].ID == DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eCommunications).ID || DeviceCollection[i].ID == DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eCommunications).ID)
-                        {
-                            // Output the result of the creation of a new AudioDevice while assining it an index, and the MMDevice itself, a default value of false, and a default communication value of true
-                            WriteObject(new AudioDevice(i + 1, DeviceCollection[i], false, true));
-                        }
-                        else
-                        {
-                            // Output the result of the creation of a new AudioDevice while assining it an index, and the MMDevice itself, a default value of false, and a default communication value of false
-                            WriteObject(new AudioDevice(i + 1, DeviceCollection[i], false, false));
-                        }
+                        // The DefaultOnly parameter was called
+
+                        // Set default communication state to use
+                        CommunicationState = Toolkit.IsDefaultCommunication(DeviceCollection[i].ID);
                     }
+
+                    // Unless the CommunicationOnly parameter was called
+                    if (!communicationOnly.ToBool())
+                    {
+                        // The CommunicationOnly parameter was not called
+
+                        // Using PolicyConfigClient, set the given device as the default device (for its type)
+                        client.SetDefaultEndpoint(DeviceCollection[i].ID, ERole.eMultimedia);
+
+                        // Set default state to use
+                        DefaultState = true;
+                    }
+                    else
+                    {
+                        // The CommunicationOnly parameter was called
+
+                        // Set default state to use
+                        DefaultState = Toolkit.IsDefault(DeviceCollection[i].ID);
+                    }
+
+                    // Output the result of the creation of a new AudioDevice, while assining it its index, the MMDevice itself, its default state, and its default communication state
+                    WriteObject(new AudioDevice(i + 1, DeviceCollection[i], DefaultState, CommunicationState));
 
                     // Stop checking for other parameters
                     return;

--- a/SOURCE/AudioDeviceCmdlets.cs
+++ b/SOURCE/AudioDeviceCmdlets.cs
@@ -882,21 +882,21 @@ namespace AudioDeviceCmdlets
             // Create a new MMDeviceEnumerator
             MMDeviceEnumerator DevEnum = new MMDeviceEnumerator();
 
-            MMDeviceCollection DeviceCollection = null;
-            try
-            {
-                // Enumerate all enabled devices in a collection
-                DeviceCollection = DevEnum.EnumerateAudioEndPoints(EDataFlow.eAll, EDeviceState.DEVICE_STATE_ACTIVE);
-            }
-            catch
-            {
-                // Error
-                throw new System.Exception("Error in cmdlet Set - Failed to create the collection of all enabled MMDevice using MMDeviceEnumerator");
-            }
-
             // If the InputObject parameter received a value
             if (inputObject != null)
             {
+                MMDeviceCollection DeviceCollection = null;
+                try
+                {
+                    // Enumerate all enabled devices in a collection
+                    DeviceCollection = DevEnum.EnumerateAudioEndPoints(EDataFlow.eAll, EDeviceState.DEVICE_STATE_ACTIVE);
+                }
+                catch
+                {
+                    // Error
+                    throw new System.Exception("Error in parameter InputObject - Failed to create the collection of all enabled MMDevice using MMDeviceEnumerator");
+                }
+
                 // For every MMDevice in DeviceCollection
                 for (int i = 0; i < DeviceCollection.Count; i++)
                 {
@@ -966,6 +966,18 @@ namespace AudioDeviceCmdlets
             // If the ID parameter received a value
             if (!string.IsNullOrEmpty(id))
             {
+                MMDeviceCollection DeviceCollection = null;
+                try
+                {
+                    // Enumerate all enabled devices in a collection
+                    DeviceCollection = DevEnum.EnumerateAudioEndPoints(EDataFlow.eAll, EDeviceState.DEVICE_STATE_ACTIVE);
+                }
+                catch
+                {
+                    // Error
+                    throw new System.Exception("Error in parameter ID - Failed to create the collection of all enabled MMDevice using MMDeviceEnumerator");
+                }
+
                 // For every MMDevice in DeviceCollection
                 for (int i = 0; i < DeviceCollection.Count; i++)
                 {
@@ -1035,6 +1047,18 @@ namespace AudioDeviceCmdlets
             // If the Index parameter received a value
             if (index != null)
             {
+                MMDeviceCollection DeviceCollection = null;
+                try
+                {
+                    // Enumerate all enabled devices in a collection
+                    DeviceCollection = DevEnum.EnumerateAudioEndPoints(EDataFlow.eAll, EDeviceState.DEVICE_STATE_ACTIVE);
+                }
+                catch
+                {
+                    // Error
+                    throw new System.Exception("Error in parameter Index - Failed to create the collection of all enabled MMDevice using MMDeviceEnumerator");
+                }
+
                 // If the Index is valid
                 if (index.Value >= 1 && index.Value <= DeviceCollection.Count)
                 {

--- a/SOURCE/AudioDeviceCmdlets.cs
+++ b/SOURCE/AudioDeviceCmdlets.cs
@@ -83,10 +83,10 @@ namespace AudioDeviceCmdlets
         // Method to find out, in a collection of all enabled MMDevice, the Index of a MMDevice, given its ID
         public int FindIndex(string ID)
         {
-            // Enumarate all enabled devices in a collection
             MMDeviceCollection DeviceCollection = null;
             try
             {
+                // Enumarate all enabled devices in a collection
                 DeviceCollection = DevEnum.EnumerateAudioEndPoints(EDataFlow.eAll, EDeviceState.DEVICE_STATE_ACTIVE);
             }
             catch
@@ -113,10 +113,10 @@ namespace AudioDeviceCmdlets
         // Method to find out if a MMDevice is the default MMDevice of its type, given its ID
         public bool IsDefault(string ID)
         {
-            // Try to get the ID of the default playback device
             string PlaybackID = "";
             try
             {
+                // Get the ID of the default playback device
                 PlaybackID = (DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eMultimedia)).ID;
             }
             catch { }
@@ -127,10 +127,10 @@ namespace AudioDeviceCmdlets
                 return (true);
             }
 
-            // Try to get the ID of the default recording device
             string RecordingID = "";
             try
             {
+                // Get the ID of the default recording device
                 RecordingID = (DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eMultimedia)).ID;
             }
             catch { }
@@ -147,10 +147,10 @@ namespace AudioDeviceCmdlets
         // Method to find out if a MMDevice is the default communication MMDevice of its type, given its ID
         public bool IsDefaultCommunication(string ID)
         {
-            // Try to get the ID of the default communication playback device
             string PlaybackCommunicationID = "";
             try
             {
+                // Get the ID of the default communication playback device
                 PlaybackCommunicationID = (DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eCommunications)).ID;
             }
             catch { }
@@ -161,10 +161,10 @@ namespace AudioDeviceCmdlets
                 return (true);
             }
 
-            // Try to get the ID of the default communication recording device
             string RecordingCommunicationID = "";
             try
             {
+                // Get the ID of the default communication recording device
                 RecordingCommunicationID = (DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eCommunications)).ID;
             }
             catch { }
@@ -331,10 +331,10 @@ namespace AudioDeviceCmdlets
                 // Create a AudioDeviceCreationToolkit
                 AudioDeviceCreationToolkit Toolkit = new AudioDeviceCreationToolkit(DevEnum);
 
-                // Enumarate all enabled devices in a collection
                 MMDeviceCollection DeviceCollection = null;
                 try
                 {
+                    // Enumarate all enabled devices in a collection
                     DeviceCollection = DevEnum.EnumerateAudioEndPoints(EDataFlow.eAll, EDeviceState.DEVICE_STATE_ACTIVE);
                 }
                 catch
@@ -360,10 +360,10 @@ namespace AudioDeviceCmdlets
                 // Create a AudioDeviceCreationToolkit
                 AudioDeviceCreationToolkit Toolkit = new AudioDeviceCreationToolkit(DevEnum);
 
-                // Enumarate all enabled devices in a collection
                 MMDeviceCollection DeviceCollection = null;
                 try
                 {
+                    // Enumarate all enabled devices in a collection
                     DeviceCollection = DevEnum.EnumerateAudioEndPoints(EDataFlow.eAll, EDeviceState.DEVICE_STATE_ACTIVE);
                 }
                 catch
@@ -396,10 +396,10 @@ namespace AudioDeviceCmdlets
                 // Create a AudioDeviceCreationToolkit
                 AudioDeviceCreationToolkit Toolkit = new AudioDeviceCreationToolkit(DevEnum);
 
-                // Enumarate all enabled devices in a collection
                 MMDeviceCollection DeviceCollection = null;
                 try
                 {
+                    // Enumarate all enabled devices in a collection
                     DeviceCollection = DevEnum.EnumerateAudioEndPoints(EDataFlow.eAll, EDeviceState.DEVICE_STATE_ACTIVE);
                 }
                 catch
@@ -433,10 +433,10 @@ namespace AudioDeviceCmdlets
                 // Create a AudioDeviceCreationToolkit
                 AudioDeviceCreationToolkit Toolkit = new AudioDeviceCreationToolkit(DevEnum);
 
-                // Get the default communication playback device
                 MMDevice Device = null;
                 try
                 {
+                    // Get the default communication playback device
                     Device = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eCommunications);
                 }
                 catch
@@ -455,10 +455,10 @@ namespace AudioDeviceCmdlets
             // If the PlaybackCommunicationMute switch parameter was called
             if (playbackcommunicationmute)
             {
-                // Get the default communication playback device
                 MMDevice Device = null;
                 try
                 {
+                    // Get the default communication playback device
                     Device = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eCommunications);
                 }
                 catch
@@ -477,10 +477,10 @@ namespace AudioDeviceCmdlets
             // If the PlaybackCommunicationVolume switch parameter was called
             if (playbackcommunicationvolume)
             {
-                // Get the default communication playback device
                 MMDevice Device = null;
                 try
                 {
+                    // Get the default communication playback device
                     Device = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eCommunications);
                 }
                 catch
@@ -502,10 +502,10 @@ namespace AudioDeviceCmdlets
                 // Create a AudioDeviceCreationToolkit
                 AudioDeviceCreationToolkit Toolkit = new AudioDeviceCreationToolkit(DevEnum);
 
-                // Get the default playback device
                 MMDevice Device = null;
                 try
                 {
+                    // Get the default playback device
                     Device = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eMultimedia);
                 }
                 catch
@@ -524,10 +524,10 @@ namespace AudioDeviceCmdlets
             // If the PlaybackMute switch parameter was called
             if (playbackmute)
             {
-                // Get the default playback device
                 MMDevice Device = null;
                 try
                 {
+                    // Get the default playback device
                     Device = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eMultimedia);
                 }
                 catch
@@ -546,10 +546,10 @@ namespace AudioDeviceCmdlets
             // If the PlaybackVolume switch parameter was called
             if(playbackvolume)
             {
-                // Get the default playback device
                 MMDevice Device = null;
                 try
                 {
+                    // Get the default playback device
                     Device = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eMultimedia);
                 }
                 catch
@@ -571,10 +571,10 @@ namespace AudioDeviceCmdlets
                 // Create a AudioDeviceCreationToolkit
                 AudioDeviceCreationToolkit Toolkit = new AudioDeviceCreationToolkit(DevEnum);
 
-                // Get the default communication recording device
                 MMDevice Device = null;
                 try
                 {
+                    // Get the default communication recording device
                     Device = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eCommunications);
                 }
                 catch
@@ -593,10 +593,10 @@ namespace AudioDeviceCmdlets
             // If the RecordingCommunicationMute switch parameter was called
             if (recordingcommunicationmute)
             {
-                // Get the default communication recording device
                 MMDevice Device = null;
                 try
                 {
+                    // Get the default communication recording device
                     Device = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eCommunications);
                 }
                 catch
@@ -615,10 +615,10 @@ namespace AudioDeviceCmdlets
             // If the RecordingCommunicationVolume switch parameter was called
             if (recordingcommunicationvolume)
             {
-                // Get the default communication recording device
                 MMDevice Device = null;
                 try
                 {
+                    // Get the default communication recording device
                     Device = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eCommunications);
                 }
                 catch
@@ -640,10 +640,10 @@ namespace AudioDeviceCmdlets
                 // Create a AudioDeviceCreationToolkit
                 AudioDeviceCreationToolkit Toolkit = new AudioDeviceCreationToolkit(DevEnum);
 
-                // Get the default recording device
                 MMDevice Device = null;
                 try
                 {
+                    // Get the default recording device
                     Device = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eMultimedia);
                 }
                 catch
@@ -662,10 +662,10 @@ namespace AudioDeviceCmdlets
             // If the RecordingMute switch parameter was called
             if (recordingmute)
             {
-                // Get the default recording device
                 MMDevice Device = null;
                 try
                 {
+                    // Get the default recording device
                     Device = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eMultimedia);
                 }
                 catch
@@ -684,10 +684,10 @@ namespace AudioDeviceCmdlets
             // If the RecordingVolume switch parameter was called
             if (recordingvolume)
             {
-                // Get the default recording device
                 MMDevice Device = null;
                 try
                 {
+                    // Get the default recording device
                     Device = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eMultimedia);
                 }
                 catch
@@ -881,10 +881,10 @@ namespace AudioDeviceCmdlets
             // Create a new MMDeviceEnumerator
             MMDeviceEnumerator DevEnum = new MMDeviceEnumerator();
 
-            // Enumarate all enabled devices in a collection
             MMDeviceCollection DeviceCollection = null;
             try
             {
+                // Enumarate all enabled devices in a collection
                 DeviceCollection = DevEnum.EnumerateAudioEndPoints(EDataFlow.eAll, EDeviceState.DEVICE_STATE_ACTIVE);
             }
             catch
@@ -1368,10 +1368,10 @@ namespace AudioDeviceCmdlets
             // If the PlaybackCommunicationMeter parameter was called
             if (playbackcommunicationmeter)
             {
-                // Get the name of the default communication playback device
                 string FriendlyName = null;
                 try
                 {
+                    // Get the name of the default communication playback device
                     FriendlyName = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eCommunications).FriendlyName;
                 }
                 catch
@@ -1388,12 +1388,13 @@ namespace AudioDeviceCmdlets
                 // Loop until interruption ex: CTRL+C
                 do
                 {
-                    // Get the name of the default communication playback device
-                    // Get current audio meter master peak value
                     float MasterPeakValue;
                     try
                     {
+                        // Get the name of the default communication playback device
                         FriendlyName = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eCommunications).FriendlyName;
+
+                        // Get current audio meter master peak value
                         MasterPeakValue = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eCommunications).AudioMeterInformation.MasterPeakValue;
                     }
                     catch
@@ -1423,10 +1424,10 @@ namespace AudioDeviceCmdlets
                 // Loop until interruption ex: CTRL+C
                 do
                 {
-                    // Get current audio meter master peak value
                     float MasterPeakValue;
                     try
                     {
+                        // Get current audio meter master peak value
                         MasterPeakValue = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eCommunications).AudioMeterInformation.MasterPeakValue;
                     }
                     catch
@@ -1447,10 +1448,10 @@ namespace AudioDeviceCmdlets
             // If the PlaybackMeter parameter was called
             if (playbackmeter)
             {
-                // Get the name of the default playback device
                 string FriendlyName = null;
                 try
                 {
+                    // Get the name of the default playback device
                     FriendlyName = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eMultimedia).FriendlyName;
                 }
                 catch
@@ -1467,12 +1468,13 @@ namespace AudioDeviceCmdlets
                 // Loop until interruption ex: CTRL+C
                 do
                 {
-                    // Get the name of the default playback device
-                    // Get current audio meter master peak value
                     float MasterPeakValue;
                     try
                     {
+                        // Get the name of the default playback device
                         FriendlyName = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eMultimedia).FriendlyName;
+
+                        // Get current audio meter master peak value
                         MasterPeakValue = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eMultimedia).AudioMeterInformation.MasterPeakValue;
                     }
                     catch
@@ -1502,10 +1504,10 @@ namespace AudioDeviceCmdlets
                 // Loop until interruption ex: CTRL+C
                 do
                 {
-                    // Get current audio meter master peak value
                     float MasterPeakValue;
                     try
                     {
+                        // Get current audio meter master peak value
                         MasterPeakValue = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eMultimedia).AudioMeterInformation.MasterPeakValue;
                     }
                     catch
@@ -1526,10 +1528,10 @@ namespace AudioDeviceCmdlets
             // If the RecordingCommunicationMeter parameter was called
             if (recordingcommunicationmeter)
             {
-                // Get the name of the default communication recording device
                 string FriendlyName = null;
                 try
                 {
+                    // Get the name of the default communication recording device
                     FriendlyName = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eCommunications).FriendlyName;
                 }
                 catch
@@ -1546,12 +1548,13 @@ namespace AudioDeviceCmdlets
                 // Loop until interruption ex: CTRL+C
                 do
                 {
-                    // Get the name of the default communication recording device
-                    // Get current audio meter master peak value
                     float MasterPeakValue;
                     try
                     {
+                        // Get the name of the default communication recording device
                         FriendlyName = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eCommunications).FriendlyName;
+
+                        // Get current audio meter master peak value
                         MasterPeakValue = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eCommunications).AudioMeterInformation.MasterPeakValue;
                     }
                     catch
@@ -1581,10 +1584,10 @@ namespace AudioDeviceCmdlets
                 // Loop until interruption ex: CTRL+C
                 do
                 {
-                    // Get current audio meter master peak value
                     float MasterPeakValue;
                     try
                     {
+                        // Get current audio meter master peak value
                         MasterPeakValue = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eCommunications).AudioMeterInformation.MasterPeakValue;
                     }
                     catch
@@ -1605,10 +1608,10 @@ namespace AudioDeviceCmdlets
             // If the RecordingMeter parameter was called
             if (recordingmeter)
             {
-                // Get the name of the default recording device
                 string FriendlyName = null;
                 try
                 {
+                    // Get the name of the default recording device
                     FriendlyName = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eMultimedia).FriendlyName;
                 }
                 catch
@@ -1625,12 +1628,13 @@ namespace AudioDeviceCmdlets
                 // Loop until interruption ex: CTRL+C
                 do
                 {
-                    // Get the name of the default recording device
-                    // Get current audio meter master peak value
                     float MasterPeakValue;
                     try
                     {
+                        // Get the name of the default recording device
                         FriendlyName = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eMultimedia).FriendlyName;
+
+                        // Get current audio meter master peak value
                         MasterPeakValue = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eMultimedia).AudioMeterInformation.MasterPeakValue;
                     }
                     catch
@@ -1660,10 +1664,10 @@ namespace AudioDeviceCmdlets
                 // Loop until interruption ex: CTRL+C
                 do
                 {
-                    // Get current audio meter master peak value
                     float MasterPeakValue;
                     try
                     {
+                        // Get current audio meter master peak value
                         MasterPeakValue = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eMultimedia).AudioMeterInformation.MasterPeakValue;
                     }
                     catch

--- a/SOURCE/AudioDeviceCmdlets.cs
+++ b/SOURCE/AudioDeviceCmdlets.cs
@@ -216,35 +216,35 @@ namespace AudioDeviceCmdlets
             // Create a MMDeviceCollection of every devices that are enabled
             MMDeviceCollection DeviceCollection = DevEnum.EnumerateAudioEndPoints(EDataFlow.eAll, EDeviceState.DEVICE_STATE_ACTIVE);
 
+            // Get the ID of the default device and the default communication device for both type
+            string DefaultPlaybackID = null;
+            string DefaultRecordingID = null;
+            string DefaultCommunicationPlaybackID = null;
+            string DefaultCommunicationRecordingID = null;
+            try
+            {
+                DefaultPlaybackID = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eMultimedia).ID;
+            }
+            catch { }
+            try
+            {
+                DefaultRecordingID = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eMultimedia).ID;
+            }
+            catch { }
+            try
+            {
+                DefaultCommunicationPlaybackID = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eCommunications).ID;
+            }
+            catch { }
+            try
+            {
+                DefaultCommunicationRecordingID = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eCommunications).ID;
+            }
+            catch { }
+
             // If the List switch parameter was called
             if (list)
             {
-                // Get the ID of the default device and the default communication device for both type
-                string DefaultPlaybackID = null;
-                string DefaultRecordingID = null;
-                string DefaultCommunicationPlaybackID = null;
-                string DefaultCommunicationRecordingID = null;
-                try
-                {
-                    DefaultPlaybackID = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eMultimedia).ID;
-                }
-                catch { }
-                try
-                {
-                    DefaultRecordingID = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eMultimedia).ID;
-                }
-                catch { }
-                try
-                {
-                    DefaultCommunicationPlaybackID = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eCommunications).ID;
-                }
-                catch { }
-                try
-                {
-                    DefaultCommunicationRecordingID = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eCommunications).ID;
-                }
-                catch { }
-
                 // For every MMDevice in DeviceCollection
                 for (int i = 0; i < DeviceCollection.Count; i++)
                 {
@@ -286,32 +286,6 @@ namespace AudioDeviceCmdlets
             // If the ID parameter received a value
             if (!string.IsNullOrEmpty(id))
             {
-                // Get the ID of the default device and the default communication device for both type
-                string DefaultPlaybackID = null;
-                string DefaultRecordingID = null;
-                string DefaultCommunicationPlaybackID = null;
-                string DefaultCommunicationRecordingID = null;
-                try
-                {
-                    DefaultPlaybackID = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eMultimedia).ID;
-                }
-                catch { }
-                try
-                {
-                    DefaultRecordingID = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eMultimedia).ID;
-                }
-                catch { }
-                try
-                {
-                    DefaultCommunicationPlaybackID = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eCommunications).ID;
-                }
-                catch { }
-                try
-                {
-                    DefaultCommunicationRecordingID = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eCommunications).ID;
-                }
-                catch { }
-
                 // For every MMDevice in DeviceCollection
                 for (int i = 0; i < DeviceCollection.Count; i++)
                 {
@@ -365,32 +339,6 @@ namespace AudioDeviceCmdlets
                 {
                     // Use valid Index as iterative
                     int i = index.Value - 1;
-
-                    // Get the ID of the default device and the default communication device for both type
-                    string DefaultPlaybackID = null;
-                    string DefaultRecordingID = null;
-                    string DefaultCommunicationPlaybackID = null;
-                    string DefaultCommunicationRecordingID = null;
-                    try
-                    {
-                        DefaultPlaybackID = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eMultimedia).ID;
-                    }
-                    catch { }
-                    try
-                    {
-                        DefaultRecordingID = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eMultimedia).ID;
-                    }
-                    catch { }
-                    try
-                    {
-                        DefaultCommunicationPlaybackID = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eCommunications).ID;
-                    }
-                    catch { }
-                    try
-                    {
-                        DefaultCommunicationRecordingID = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eCommunications).ID;
-                    }
-                    catch { }
 
                     // If this MMDevice's ID is either, the same as the default playback device's ID, or the same as the default recording device's ID
                     if (DeviceCollection[i].ID == DefaultPlaybackID || DeviceCollection[i].ID == DefaultRecordingID)

--- a/SOURCE/AudioDeviceCmdlets.cs
+++ b/SOURCE/AudioDeviceCmdlets.cs
@@ -365,12 +365,38 @@ namespace AudioDeviceCmdlets
                 {
                     // Use valid Index as iterative
                     int i = index.Value - 1;
-                    
+
+                    // Get the ID of the default device and the default communication device for both type
+                    string DefaultPlaybackID = null;
+                    string DefaultRecordingID = null;
+                    string DefaultCommunicationPlaybackID = null;
+                    string DefaultCommunicationRecordingID = null;
+                    try
+                    {
+                        DefaultPlaybackID = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eMultimedia).ID;
+                    }
+                    catch { }
+                    try
+                    {
+                        DefaultRecordingID = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eMultimedia).ID;
+                    }
+                    catch { }
+                    try
+                    {
+                        DefaultCommunicationPlaybackID = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eCommunications).ID;
+                    }
+                    catch { }
+                    try
+                    {
+                        DefaultCommunicationRecordingID = DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eCommunications).ID;
+                    }
+                    catch { }
+
                     // If this MMDevice's ID is either, the same as the default playback device's ID, or the same as the default recording device's ID
-                    if (DeviceCollection[i].ID == DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eMultimedia).ID || DeviceCollection[i].ID == DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eMultimedia).ID)
+                    if (DeviceCollection[i].ID == DefaultPlaybackID || DeviceCollection[i].ID == DefaultRecordingID)
                     {
                         // If the MMDevice's ID is either, the same as the default communication playback device's ID, or the same as the default communication recording device's ID
-                        if (DeviceCollection[i].ID == DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eCommunications).ID || DeviceCollection[i].ID == DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eCommunications).ID)
+                        if (DeviceCollection[i].ID == DefaultCommunicationPlaybackID || DeviceCollection[i].ID == DefaultCommunicationRecordingID)
                         {
                             // Output the result of the creation of a new AudioDevice while assining it an index, and the MMDevice itself, a default value of true, and a default communication value of true
                             WriteObject(new AudioDevice(i + 1, DeviceCollection[i], true, true));
@@ -384,7 +410,7 @@ namespace AudioDeviceCmdlets
                     else
                     {
                         // If the MMDevice's ID is either, the same as the default communication playback device's ID, or the same as the default communication recording device's ID
-                        if (DeviceCollection[i].ID == DevEnum.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eCommunications).ID || DeviceCollection[i].ID == DevEnum.GetDefaultAudioEndpoint(EDataFlow.eCapture, ERole.eCommunications).ID)
+                        if (DeviceCollection[i].ID == DefaultCommunicationPlaybackID || DeviceCollection[i].ID == DefaultCommunicationRecordingID)
                         {
                             // Output the result of the creation of a new AudioDevice while assining it an index, and the MMDevice itself, a default value of false, and a default communication value of true
                             WriteObject(new AudioDevice(i + 1, DeviceCollection[i], false, true));


### PR DESCRIPTION
This will make sure not to end in error anymore when there is not at least one enabled device to take the default and default communication role for both type.  

TODO:
```cs
```
DONE:
```cs
try
{
    var = DevEnum.EnumerateAudioEndPoints(EDataFlow, EDeviceState);
}
catch { }
```
```cs
try
{
    var = DevEnum.GetDefaultAudioEndpoint(EDataFlow, ERole);
}
catch { }
```